### PR TITLE
Include original input in thrown error

### DIFF
--- a/src/Check.ts
+++ b/src/Check.ts
@@ -87,7 +87,7 @@ export class Check {
 		// remove last character from concatenated error message.
 		error_message = error_message.slice(0, -1);
 
-		const error = new CheckError(error_message, this.schema);
+		const error = new CheckError(error_message, this.schema, object);
 
 		throw error;
 	}

--- a/src/CheckError.test.ts
+++ b/src/CheckError.test.ts
@@ -3,6 +3,9 @@ import { CheckError } from './CheckError';
 import { Schema } from 'jsonschema';
 
 describe('CheckError', () => {
+	const schema: Schema = { type: 'object' };
+	const input = 'something';
+
 	it('should set the message property correctly', () => {
 		const error = new CheckError('Test error message');
 		expect(error.message).to.equal('Test error message');
@@ -19,7 +22,6 @@ describe('CheckError', () => {
 	});
 
 	it('should handle the schema property when provided', () => {
-		const schema: Schema = { type: 'object' };
 		const error = new CheckError('Test error message', schema);
 		expect(error.schema).to.deep.equal(schema);
 	});
@@ -27,5 +29,15 @@ describe('CheckError', () => {
 	it('should handle the schema property when omitted', () => {
 		const error = new CheckError('Test error message');
 		expect(error.schema).to.be.undefined;
+	});
+
+	it('should handle the input property when provided', () => {
+		const error = new CheckError('Test error message', schema, input);
+		expect(error.input).to.equal(input);
+	});
+
+	it('should handle the input property when omitted', () => {
+		const error = new CheckError('Test error message');
+		expect(error.input).to.be.undefined;
 	});
 });

--- a/src/CheckError.ts
+++ b/src/CheckError.ts
@@ -14,14 +14,23 @@ export class CheckError extends Error {
 	schema: Schema | undefined;
 
 	/**
+	 * The input that caused the validation error.
+	 *
+	 * @type {any}
+	 */
+	input: any;
+
+	/**
 	 * Creates a new instance of CheckError.
 	 *
 	 * @param {string} message - The error message describing the validation failure.
 	 * @param {Schema} [schema] - The schema that failed to validate (optional).
+	 * @param {any} [input] - The input that caused the validation error.
 	 */
-	constructor(message: string, schema?: Schema) {
+	constructor(message: string, schema?: Schema, input?: any) {
 		super(message);
 		this.name = 'CheckError';
 		this.schema = schema;
+		this.input = input;
 	}
 }


### PR DESCRIPTION
Useful to see downstream what caused the validation error.