### PR TITLE
Fix empty items array normalization

### DIFF
--- a/documentation/PULL_REQUESTS/2026-04-16-fix-empty-tuple.md
+++ b/documentation/PULL_REQUESTS/2026-04-16-fix-empty-tuple.md
@@ -1,0 +1,16 @@
+# Problem
+
+Legacy schemas using `items: []` (an empty tuple array) caused a compile-time error when passed to AJV. The schema normalizer was converting `items: []` to `prefixItems: []`, which the 2020-12 meta-schema rejects because `prefixItems` requires at least one item.
+
+# Solution
+
+Added a length guard to the tuple normalization logic. When `items` is an empty array, we now skip setting `prefixItems` entirely (since an empty tuple prefix is a no-op) while still correctly converting `additionalItems` to `items`. This means legacy schemas with `items: []` now compile and validate correctly — empty arrays pass, and non-empty arrays are rejected as expected.
+
+# How It Works
+
+Schemas that previously crashed on construction now work seamlessly. An empty tuple declaration like `{ type: 'array', items: [] }` correctly enforces that the array must be empty.
+
+# Credits
+
+- Nabs (Architect)
+- JENA (Lead Developer)

--- a/src/Check.test.ts
+++ b/src/Check.test.ts
@@ -2680,6 +2680,31 @@ describe('audit gap coverage', () => {
 				expect(() => check.test({ value: true })).to.throw(CheckError);
 			});
 		});
+
+		describe('empty items array normalization', () => {
+			it('should not throw on construction with items: [] and additionalItems: false', () => {
+				const check = new Check({
+					type: 'array',
+					items: [],
+					additionalItems: false,
+				} as any);
+				// Empty array should pass (no items, none allowed)
+				expect(() => check.test([])).to.not.throw();
+				// Non-empty array should fail (no items allowed)
+				expect(() => check.test(['a'])).to.throw(CheckError);
+			});
+
+			it('should not throw on construction with items: [] and no additionalItems', () => {
+				const check = new Check({
+					type: 'array',
+					items: [],
+				} as any);
+				// Empty array should pass
+				expect(() => check.test([])).to.not.throw();
+				// Non-empty array should fail (default is items: false)
+				expect(() => check.test(['a'])).to.throw(CheckError);
+			});
+		});
 	});
 
 });

--- a/src/normalizeSchema.test.ts
+++ b/src/normalizeSchema.test.ts
@@ -74,6 +74,40 @@ describe('normalizeSchema', () => {
 			expect(result.prefixItems).to.deep.equal([{ type: 'string' }, { type: 'number' }]);
 			expect(result.items).to.equal(false);
 		});
+
+		it('should not set prefixItems when items is an empty array with additionalItems false', () => {
+			const schema = {
+				type: 'array' as const,
+				items: [] as any[],
+				additionalItems: false,
+			};
+			const result = normalizeSchema(schema);
+			expect(result).to.not.have.property('prefixItems');
+			expect(result.items).to.equal(false);
+			expect(result).to.not.have.property('additionalItems');
+		});
+
+		it('should not set prefixItems when items is an empty array without additionalItems', () => {
+			const schema = {
+				type: 'array' as const,
+				items: [] as any[],
+			};
+			const result = normalizeSchema(schema);
+			expect(result).to.not.have.property('prefixItems');
+			expect(result.items).to.equal(false);
+		});
+
+		it('should not set prefixItems when items is an empty array with additionalItems true', () => {
+			const schema = {
+				type: 'array' as const,
+				items: [] as any[],
+				additionalItems: true,
+			};
+			const result = normalizeSchema(schema);
+			expect(result).to.not.have.property('prefixItems');
+			expect(result.items).to.equal(true);
+			expect(result).to.not.have.property('additionalItems');
+		});
 	});
 
 	describe('deep clone', () => {

--- a/src/normalizeSchema.ts
+++ b/src/normalizeSchema.ts
@@ -65,11 +65,20 @@ function normalizeNode(node: Record<string, unknown>): void {
 	}
 
 	// --- Convert legacy tuple syntax ---
-	if (Array.isArray(node.items)) {
+	if (Array.isArray(node.items) && node.items.length > 0) {
 		// Move items array to prefixItems
 		node.prefixItems = node.items;
 
 		// Convert additionalItems → items (default to false if absent)
+		if ('additionalItems' in node) {
+			node.items = node.additionalItems;
+			delete node.additionalItems;
+		} else {
+			node.items = false;
+		}
+	} else if (Array.isArray(node.items) && node.items.length === 0) {
+		// Empty tuple: no prefixItems needed (empty array is a no-op)
+		// Still convert additionalItems → items (default to false if absent)
 		if ('additionalItems' in node) {
 			node.items = node.additionalItems;
 			delete node.additionalItems;


### PR DESCRIPTION
# Problem

Legacy schemas using `items: []` (an empty tuple array) caused a compile-time error when passed to AJV. The schema normalizer was converting `items: []` to `prefixItems: []`, which the 2020-12 meta-schema rejects because `prefixItems` requires at least one item.

# Solution

Added a length guard to the tuple normalization logic. When `items` is an empty array, we now skip setting `prefixItems` entirely (since an empty tuple prefix is a no-op) while still correctly converting `additionalItems` to `items`. This means legacy schemas with `items: []` now compile and validate correctly — empty arrays pass, and non-empty arrays are rejected as expected.

# How It Works

Schemas that previously crashed on construction now work seamlessly. An empty tuple declaration like `{ type: 'array', items: [] }` correctly enforces that the array must be empty.

# Credits

- Nabs (Architect)
- JENA (Lead Developer)
