### PR TITLE
Clean up schema compilation errors and per-item false-schema noise

### DIFF
--- a/documentation/PULL_REQUESTS/2026-04-16-clean-error-messages.md
+++ b/documentation/PULL_REQUESTS/2026-04-16-clean-error-messages.md
@@ -1,0 +1,12 @@
+# Problem
+
+Two edge cases produced confusing error messages: (1) invalid schemas surfaced raw AJV meta-schema errors repeated 8 times, and (2) schemas that disallow array items produced one "is not allowed" error per element instead of a single clear message.
+
+# Solution
+
+Schema compilation errors are now caught and deduplicated into clean, readable messages. Per-item false-schema errors are collapsed into a single message like "must not have any items."
+
+# Credits
+
+- Nabs (Architect)
+- JENA (Lead Developer)

--- a/src/Check.test.ts
+++ b/src/Check.test.ts
@@ -2788,3 +2788,69 @@ describe('audit gap coverage', () => {
 	});
 
 });
+
+describe('false schema collapsing (items: false)', () => {
+	it('should collapse per-item false-schema errors for items: [] with elements', () => {
+		const schema = {
+			type: 'array',
+			items: [] as any[],
+		};
+		const c = new Check(schema);
+		expect(() => c.test([1, 2, 3])).to.throw(
+			CheckError,
+			'`value` must not have any items.'
+		);
+	});
+
+	it('should pass when items: [] and input is empty array', () => {
+		const schema = {
+			type: 'array',
+			items: [] as any[],
+		};
+		const c = new Check(schema);
+		expect(() => c.test([])).to.not.throw();
+	});
+
+	it('should collapse nested false-schema errors with field name', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				answers: {
+					type: 'array',
+					items: [] as any[],
+				},
+			},
+		};
+		const c = new Check(schema);
+		expect(() => c.test({ answers: ['a', 'b', 'c'] })).to.throw(
+			CheckError,
+			'`answers` must not have any items.'
+		);
+	});
+
+	it('should preserve other errors alongside collapsed false-schema errors', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				answers: {
+					type: 'array',
+					items: [] as any[],
+				},
+				name: {
+					type: 'string',
+				},
+			},
+			required: ['name'],
+		};
+		const c = new Check(schema);
+		try {
+			c.test({ answers: [1, 2], name: 123 });
+			expect.fail('Expected CheckError to be thrown');
+		} catch (e: any) {
+			expect(e).to.be.instanceOf(CheckError);
+			// Should have both the collapsed items error and the type error
+			expect(e.message).to.include('must not have any items');
+			expect(e.message).to.include('name');
+		}
+	});
+});

--- a/src/Check.test.ts
+++ b/src/Check.test.ts
@@ -37,6 +37,86 @@ describe('Check class', () => {
 		});
 	});
 
+	describe('schema compilation errors', () => {
+		it('should throw a clean error for invalid items value (string)', () => {
+			const schema = {
+				type: 'array',
+				items: 'not an array',
+			};
+			expect(() => new Check(schema)).to.throw(
+				CheckError,
+				'Schema is invalid: "items" must be an object or boolean.'
+			);
+		});
+
+		it('should throw a clean error for invalid type value', () => {
+			const schema = {
+				type: 12345,
+			};
+			expect(() => new Check(schema)).to.throw(CheckError);
+			// Verify it starts with "Schema is invalid:" and doesn't repeat
+			try {
+				new Check(schema);
+			} catch (e: any) {
+				expect(e.message).to.match(/^Schema is invalid:/);
+				// Should NOT have the same path repeated multiple times in sequence
+				const occurrences = (e.message.match(/"type"/g) || []).length;
+				expect(occurrences).to.be.at.most(3);
+			}
+		});
+
+		it('should throw a clean error for deeply nested invalid schema', () => {
+			const schema = {
+				type: 'object',
+				properties: {
+					config: {
+						type: 'object',
+						properties: {
+							tags: {
+								type: 'array',
+								items: 'invalid',
+							},
+						},
+					},
+				},
+			};
+			expect(() => new Check(schema)).to.throw(CheckError);
+			try {
+				new Check(schema);
+			} catch (e: any) {
+				expect(e.message).to.match(/^Schema is invalid:/);
+				expect(e.message).to.include('properties.config.properties.tags.items');
+			}
+		});
+
+		it('should include the schema on the thrown CheckError', () => {
+			const schema = {
+				type: 'array',
+				items: 'invalid',
+			};
+			try {
+				new Check(schema);
+				expect.fail('Expected CheckError to be thrown');
+			} catch (e: any) {
+				expect(e).to.be.instanceOf(CheckError);
+				expect(e.schema).to.deep.equal(schema);
+			}
+		});
+
+		it('should still compile valid schemas without error', () => {
+			const schema = {
+				type: 'object',
+				properties: {
+					name: { type: 'string' },
+					age: { type: 'number' },
+					tags: { type: 'array', items: { type: 'string' } },
+				},
+				required: ['name'],
+			};
+			expect(() => new Check(schema)).to.not.throw();
+		});
+	});
+
 	describe('test method', () => {
 		it('should throw an error if object is null or undefined', () => {
 			expect(() => check(schema).test(null)).to.throw(CheckError, 'The first argument is null or undefined.');

--- a/src/Check.ts
+++ b/src/Check.ts
@@ -1,8 +1,102 @@
 import { ValidateFunction, SchemaObject } from 'ajv';
+import anora from 'anora';
 import { CheckError } from './CheckError';
 import { ajv } from './ajvInstance';
 import { normalizeSchema } from './normalizeSchema';
 import { normalizeErrors, formatMessage } from './formatErrors';
+
+/**
+ * Parses an AJV schema compilation error message and returns a clean,
+ * deduplicated human-readable message.
+ *
+ * AJV error format: "schema is invalid: data/path message, data/path message, ..."
+ * The same path+message can repeat up to 8 times due to multiple meta-schema validations.
+ *
+ * Output format: 'Schema is invalid: "path" message. "path2" message2.'
+ */
+function formatSchemaError(rawMessage: string): string {
+	// Strip the "schema is invalid: " prefix
+	const prefix = 'schema is invalid: ';
+	if (!rawMessage.startsWith(prefix)) {
+		return rawMessage;
+	}
+
+	const body = rawMessage.slice(prefix.length);
+
+	// Split on ", data" boundaries to get individual error fragments.
+	// Each fragment looks like: "data/items must be object,boolean"
+	// We split on ", data" and re-prepend "data" to each fragment after the first.
+	const rawParts = body.split(', data');
+	const parts: string[] = [];
+	for (let i = 0; i < rawParts.length; i++) {
+		const raw = rawParts[i];
+		if (raw === undefined) continue;
+		const part = i === 0 ? raw : 'data' + raw;
+		parts.push(part.trim());
+	}
+
+	// Deduplicate exact fragments
+	const unique = [...new Set(parts)];
+
+	// Convert each fragment from "data/path message" to '"path" message'
+	const formatted: string[] = [];
+	for (const part of unique) {
+		// Match: "data" optionally followed by "/path/segments" then " message"
+		const match = part.match(/^data(?:\/([^\s]+))?\s+(.+)$/);
+		if (!match) {
+			formatted.push(part);
+			continue;
+		}
+
+		const rawPath = match[1] ?? '';
+		const message = match[2]!;
+
+		// Convert path: "items" → "items", "properties/name/type" → "properties.name.type"
+		const dotPath = rawPath.replace(/\//g, '.');
+
+		// Clean up AJV type lists: "object,boolean" → "an object or boolean"
+		const cleanMessage = cleanTypeList(message);
+
+		if (dotPath) {
+			formatted.push(`"${dotPath}" ${cleanMessage}`);
+		} else {
+			formatted.push(cleanMessage);
+		}
+	}
+
+	return `Schema is invalid: ${formatted.join('. ')}.`;
+}
+
+/**
+ * Cleans up AJV type constraint messages.
+ * "must be object,boolean" → "must be an object or boolean"
+ * "must be string" → "must be a string"
+ * "must be array" → "must be an array"
+ */
+function cleanTypeList(message: string): string {
+	// Match "must be type1,type2,..." pattern
+	const typeListMatch = message.match(/^must be ([a-z,]+)$/);
+	if (!typeListMatch) {
+		return message;
+	}
+
+	const types = typeListMatch[1]!.split(',');
+
+	if (types.length === 1) {
+		return `must be ${anora(types[0])} ${types[0]}`;
+	}
+
+	// For multiple types: "an object or boolean"
+	const last = types[types.length - 1];
+	const rest = types.slice(0, -1);
+
+	const parts: string[] = [];
+	for (const type of rest) {
+		parts.push(`${anora(type)} ${type}`);
+	}
+
+	return `must be ${parts.join(', ')} or ${last}`;
+}
 
 /**
  * A class to perform validation on objects according to a specified schema.
@@ -20,7 +114,13 @@ export class Check {
 		if (!schema) throw new CheckError('Schema must be defined in constructor.');
 
 		this.schema = schema;
-		this.validate = ajv.compile(normalizeSchema(schema));
+
+		try {
+			this.validate = ajv.compile(normalizeSchema(schema));
+		} catch (error: unknown) {
+			const rawMessage = error instanceof Error ? error.message : String(error);
+			throw new CheckError(formatSchemaError(rawMessage), schema);
+		}
 	}
 
 	/**

--- a/src/formatErrors.test.ts
+++ b/src/formatErrors.test.ts
@@ -751,3 +751,82 @@ describe('formatMessage', () => {
 		expect(result).to.equal('`name` needs to be a `string`.');
 	});
 });
+
+describe('normalizeErrors — false schema collapsing', () => {
+	it('should collapse root-level false-schema array errors into single message', () => {
+		// Simulates items: false with [1, 2, 3]
+		const errors: ErrorObject[] = [
+			mockError({ keyword: 'false schema', instancePath: '/0', schemaPath: '#/items' }),
+			mockError({ keyword: 'false schema', instancePath: '/1', schemaPath: '#/items' }),
+			mockError({ keyword: 'false schema', instancePath: '/2', schemaPath: '#/items' }),
+		];
+		const result = normalizeErrors(errors);
+		expect(result).to.deep.equal([
+			{ field: 'value', problem: 'must not have any items' },
+		]);
+	});
+
+	it('should collapse nested false-schema array errors into single message', () => {
+		// Simulates properties.answers with items: false and ['a', 'b']
+		const errors: ErrorObject[] = [
+			mockError({ keyword: 'false schema', instancePath: '/answers/0', schemaPath: '#/properties/answers/items' }),
+			mockError({ keyword: 'false schema', instancePath: '/answers/1', schemaPath: '#/properties/answers/items' }),
+		];
+		const result = normalizeErrors(errors);
+		expect(result).to.deep.equal([
+			{ field: 'answers', problem: 'must not have any items' },
+		]);
+	});
+
+	it('should not collapse a single false-schema error', () => {
+		// Only one item — don't collapse
+		const errors: ErrorObject[] = [
+			mockError({ keyword: 'false schema', instancePath: '/0', schemaPath: '#/items' }),
+		];
+		const result = normalizeErrors(errors);
+		expect(result).to.deep.equal([
+			{ field: '[0]', problem: 'is not allowed' },
+		]);
+	});
+
+	it('should preserve non-false-schema errors alongside collapsed ones', () => {
+		// Mix: false-schema items + a type error
+		const errors: ErrorObject[] = [
+			mockError({ keyword: 'false schema', instancePath: '/0', schemaPath: '#/items' }),
+			mockError({ keyword: 'false schema', instancePath: '/1', schemaPath: '#/items' }),
+			mockError({ keyword: 'type', instancePath: '/name', schemaPath: '#/properties/name/type', params: { type: 'string' } }),
+		];
+		const result = normalizeErrors(errors);
+		expect(result).to.have.length(2);
+
+		const fields = result.map((r) => r.field);
+		expect(fields).to.include('value');
+		expect(fields).to.include('name');
+
+		const valueError = result.find((r) => r.field === 'value');
+		expect(valueError!.problem).to.equal('must not have any items');
+
+		const nameError = result.find((r) => r.field === 'name');
+		expect(nameError!.problem).to.equal('needs to be a `string`');
+	});
+
+	it('should collapse multiple independent groups separately', () => {
+		// Two different parents: root-level and nested
+		const errors: ErrorObject[] = [
+			mockError({ keyword: 'false schema', instancePath: '/0', schemaPath: '#/items' }),
+			mockError({ keyword: 'false schema', instancePath: '/1', schemaPath: '#/items' }),
+			mockError({ keyword: 'false schema', instancePath: '/nested/0', schemaPath: '#/properties/nested/items' }),
+			mockError({ keyword: 'false schema', instancePath: '/nested/1', schemaPath: '#/properties/nested/items' }),
+		];
+		const result = normalizeErrors(errors);
+		expect(result).to.have.length(2);
+
+		const fields = result.map((r) => r.field);
+		expect(fields).to.include('value');
+		expect(fields).to.include('nested');
+
+		for (const entry of result) {
+			expect(entry.problem).to.equal('must not have any items');
+		}
+	});
+});

--- a/src/formatErrors.ts
+++ b/src/formatErrors.ts
@@ -325,6 +325,77 @@ function findBestBranchErrors(
 }
 
 /**
+ * Detects groups of "is not allowed" errors that share a parent path and
+ * differ only by array index, and collapses each group into a single
+ * "must not have any items" error.
+ *
+ * Example:
+ *   [{ field: '[0]', problem: 'is not allowed' },
+ *    { field: '[1]', problem: 'is not allowed' },
+ *    { field: '[2]', problem: 'is not allowed' }]
+ * →
+ *   [{ field: 'value', problem: 'must not have any items' }]
+ *
+ * Nested example:
+ *   [{ field: 'answers[0]', problem: 'is not allowed' },
+ *    { field: 'answers[1]', problem: 'is not allowed' }]
+ * →
+ *   [{ field: 'answers', problem: 'must not have any items' }]
+ */
+function collapseFalseSchemaErrors(
+	results: Array<{ field: string; problem: string }>
+): Array<{ field: string; problem: string }> {
+	// Separate "is not allowed" errors with array-index fields from everything else
+	const arrayItemPattern = /^(.*?)\.?\[(\d+)\]$/;
+	const collapsible: Map<string, number> = new Map();
+	const other: Array<{ field: string; problem: string }> = [];
+
+	for (const entry of results) {
+		if (entry.problem !== 'is not allowed') {
+			other.push(entry);
+			continue;
+		}
+
+		const match = entry.field.match(arrayItemPattern);
+		if (!match) {
+			other.push(entry);
+			continue;
+		}
+
+		// Parent path: '' for root-level ([0], [1]), 'answers' for answers[0], answers[1]
+		const parent = match[1] as string;
+		collapsible.set(parent, (collapsible.get(parent) || 0) + 1);
+	}
+
+	// Only collapse groups with 2+ errors (a single [0] error stays as-is)
+	const collapsed: Array<{ field: string; problem: string }> = [];
+	const collapsedParents = new Set<string>();
+
+	for (const [parent, count] of collapsible) {
+		if (count >= 2) {
+			const field = parent || 'value';
+			collapsed.push({ field, problem: 'must not have any items' });
+			collapsedParents.add(parent);
+		}
+	}
+
+	// Re-add non-collapsed "is not allowed" entries
+	for (const entry of results) {
+		if (entry.problem !== 'is not allowed') continue;
+
+		const match = entry.field.match(arrayItemPattern);
+		if (!match) continue;
+
+		const parent = match[1] as string;
+		if (!collapsedParents.has(parent)) {
+			other.push(entry);
+		}
+	}
+
+	return [...collapsed, ...other];
+}
+
+/**
  * Filters, maps, and deduplicates AJV errors into field/problem tuples.
  *
  * - Filters out child errors from oneOf/anyOf compounds (unless discriminator is present)
@@ -388,9 +459,12 @@ function normalizeErrors(errors: ErrorObject[]): Array<{ field: string; problem:
 		problem: formatProblem(error),
 	}));
 
+	// Step 4.5: Collapse false-schema array-item errors into single messages
+	const collapsed = collapseFalseSchemaErrors(results);
+
 	// Step 5: Deduplicate by (field, problem) tuple
 	const seen = new Set<string>();
-	return results.filter(({ field, problem }) => {
+	return collapsed.filter(({ field, problem }) => {
 		const key = `${field}::${problem}`;
 		if (seen.has(key)) return false;
 		seen.add(key);


### PR DESCRIPTION
# Problem

Two edge cases produced confusing error messages: (1) invalid schemas surfaced raw AJV meta-schema errors repeated 8 times, and (2) schemas that disallow array items produced one "is not allowed" error per element instead of a single clear message.

# Solution

Schema compilation errors are now caught and deduplicated into clean, readable messages. Per-item false-schema errors are collapsed into a single message like "must not have any items."

# Credits

- Nabs (Architect)
- JENA (Lead Developer)
